### PR TITLE
[DDCI-124] - added vocab auto complete

### DIFF
--- a/ckanext/vocabulary_services/blueprint.py
+++ b/ckanext/vocabulary_services/blueprint.py
@@ -6,6 +6,8 @@ import logging
 from ckan.common import request
 from ckanext.vocabulary_services import helpers
 from flask import Blueprint
+from ckan.views.api import _finish_ok
+from pprint import pformat
 
 clean_dict = logic.clean_dict
 get_action = toolkit.get_action
@@ -132,8 +134,24 @@ def delete(id):
 
     return h.redirect_to('vocabulary_services.index')
 
+def vocabulary_service_term_autocomplete(term_name):
+    q = request.args.get('incomplete', '')
+    limit = request.args.get('limit', 5)
+    search_dict = {'term_name': term_name, 'q': q, 'limit': limit}
+
+    if not q:
+        return _finish_ok({})
+
+    result = get_action('vocabulary_service_term_search')({}, search_dict)
+    if not result:
+        return _finish_ok({})
+
+    result_set = {'ResultSet': {u'Result': result}}
+
+    return _finish_ok(result_set)
 
 vocabulary_services.add_url_rule(u'/vocabulary-services', methods=[u'GET', u'POST'], view_func=index)
 vocabulary_services.add_url_rule(u'/vocabulary-service/refresh/<id>', view_func=refresh)
 vocabulary_services.add_url_rule(u'/vocabulary-service/terms/<id>', view_func=terms)
 vocabulary_services.add_url_rule(u'/vocabulary-service/delete/<id>', methods=[u'POST'], view_func=delete)
+vocabulary_services.add_url_rule(u'/vocabulary-service/term-autocomplete/<term_name>', view_func=vocabulary_service_term_autocomplete)

--- a/ckanext/vocabulary_services/logic/action/get.py
+++ b/ckanext/vocabulary_services/logic/action/get.py
@@ -179,3 +179,20 @@ def remote_csv_vocabulary_terms(context, data_dict):
             log.error(str(e))
 
     return False
+
+def vocabulary_service_term_search(context, search_dict):
+    vocab_service = vocabulary_service(context, search_dict['term_name'])
+    if not vocab_service:
+        return None
+
+    cls = model.VocabularyServiceTerm
+    result = cls.Session.query(cls).filter(cls.vocabulary_service_id == vocab_service.id).filter(
+        cls.label.contains(search_dict['q'])).limit(search_dict['limit']).all()
+    if not result:
+        return None
+
+    data = []
+    for item in result:
+        data.append({'value': item.uri, 'name': item.label})
+
+    return data

--- a/ckanext/vocabulary_services/plugin.py
+++ b/ckanext/vocabulary_services/plugin.py
@@ -37,6 +37,7 @@ class VocabularyServicesPlugin(plugins.SingletonPlugin):
             'get_csiro_vocabulary_terms': get.csiro_vocabulary_terms,
             'get_remote_csv_vocabulary_terms': get.remote_csv_vocabulary_terms,
             'get_vocprez_vocabulary_terms': get.vocprez_vocabulary_terms,
+            'vocabulary_service_term_search': get.vocabulary_service_term_search,
             'vocabulary_service_create': create.vocabulary_service_create,
             'vocabulary_service_edit': update.vocabulary_service_edit,
             'vocabulary_service_delete': update.vocabulary_service_delete,


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-124

@salsa-nathan there are issues here.
how it is work based on the solution direction
- text field becomes autocomplete
- filter by the label, and the value is URI as per other vocab.

issue:
- when there is an **error** or **on edit form,** the value become URI instead of the label, 
I tried to add a hidden field to hold the value and render the label, etc, but still got issue when there is an error on the new dataset form. and I haven't found a solution for this. 

and if we can change the field to dropdown, and dynamically have the dropdown updated based on the ajax, it seems there is a plenty of work, since I am not sure if the js plugin is supporting this OOTB.


![image](https://user-images.githubusercontent.com/1538818/94913777-08ac0080-04d4-11eb-99ee-22c298e87bda.png)

on edit/error form
![image](https://user-images.githubusercontent.com/1538818/94913817-1e212a80-04d4-11eb-939d-908d6e3d021b.png)

FE
![image](https://user-images.githubusercontent.com/1538818/94913840-2c6f4680-04d4-11eb-8733-fcafc33c265a.png)

example field
```  
  {
      "field_name": "test_field",
      "label": "Test Field",
      "preset": "qdes_vocab_service_autocomplete",
      "vocabulary_service_name": "spatial_name_code",
      "form_placeholder": "Select a Test Field",
      "form_attrs": {
        "data-module": "qdes_autocomplete",
        "data-module-source": "/ckan-admin/vocabulary-service/term-autocomplete/spatial_name_code?incomplete=?",
        "data-module-key": "value",
        "data-module-label": "label"
      }
    },
```
