### PR TITLE
Update controlled vocabulary service to handle definitions (Backend) 

### DIFF
--- a/ckanext/vocabulary_services/helpers.py
+++ b/ckanext/vocabulary_services/helpers.py
@@ -33,7 +33,7 @@ def scheming_vocabulary_service_choices(field):
     if vocabulary_service_name:
         try:
             for term in get_action('get_vocabulary_service_terms')({}, vocabulary_service_name):
-                choices.append({'value': term.uri, 'label': term.label})
+                choices.append({'value': term.uri, 'label': term.label, 'title': term.definition})
         except Exception as e:
             log.error(str(e))
 


### PR DESCRIPTION
Added 'definition' to new property 'title' for 'scheming_vocabulary_service_choices'
This property will be required for the frontend to display the definition as a tooltip