### PR TITLE
[DDCI-170] - fix refresh issue

### DIFF
--- a/ckanext/vocabulary_services/logic/action/get.py
+++ b/ckanext/vocabulary_services/logic/action/get.py
@@ -78,7 +78,15 @@ def csiro_vocabulary_terms(context, data_dict):
                         term = response['@graph'][i]
                         uri = term.get('@id', None)
                         label = term.get('rdfs:label', None)
+                        if type(label) is dict:
+                            label = label.get('@value')
+                        elif type(label) is list:
+                            label = label[0]
+
                         definition = term.get('skos:definition', None) or term.get('dct:description', None)
+                        if type(definition) is dict:
+                            definition = definition.get('@value')
+
                         if uri and label:
                             # Create the term in the internal vocabulary service
                             get_action('vocabulary_service_term_upsert')(context, {


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-170

apparently the json data from external sources has variation.

http://registry.it.csiro.au/def/environment/property?_format=jsonld
```
    "rdfs:label" : "chemical oxygen demand",
    "rdfs:label" : [ "iron sulfide concentration", "iron sulphide concentration" ],
    "rdfs:label" : {
      "@language" : "en",
      "@value" : "chemistry observable properties"
    },


   "dct:description" : "concentration of chromium (hexavalent and trivalent forms) as Cr ",
   "dct:description" : {
      "@language" : "en",
      "@value" : "chlordane concentration"
    },
```