### PR TITLE
[DDCI-696] Fix for secure vocab search

### DIFF
--- a/ckanext/vocabulary_services/secure/blueprint.py
+++ b/ckanext/vocabulary_services/secure/blueprint.py
@@ -91,8 +91,8 @@ def secure_vocabulary_search(vocabulary_name):
     try:
         context = {
             'model': model,
-            'user': c.user,
-            'auth_user_obj': c.userobj
+            'user': toolkit.g.user,
+            'auth_user_obj': toolkit.g.userobj
         }
         toolkit.check_access(u'package_create', context)
     except toolkit.NotAuthorized:

--- a/ckanext/vocabulary_services/secure/logic/action/get.py
+++ b/ckanext/vocabulary_services/secure/logic/action/get.py
@@ -48,7 +48,7 @@ def secure_vocabulary_record(context, data_dict):
 
 
 def secure_vocabulary_search(context, data_dict):
-    if not authz.has_user_permission_for_some_org(context.get('user'), 'create_dataset'):
+    if not authz.is_sysadmin(context.get('user')) and not authz.has_user_permission_for_some_org(context.get('user'), 'create_dataset'):
         return {'success': False, 'msg': toolkit._('Not authorized')}
 
     results = []


### PR DESCRIPTION
- Allow sysadmins without any organisation roles to access `secure_vocabulary_search` get action
- Replaced use of `c.user` and `c.userobj` with `toolkit.g` equivalents