### PR TITLE
[DDCI-777] Show only logged in user's datasets for review

### DIFF
--- a/ckanext/vocabulary_services/secure/secure_vocabularies.json
+++ b/ckanext/vocabulary_services/secure/secure_vocabularies.json
@@ -19,7 +19,8 @@
     ],
     "search_fields": [
       "Functional Position",
-      "Name"
+      "Name",
+      "Email"
     ],
     "search_display_fields": {
       "value": "{PositionID}",


### PR DESCRIPTION
Add the `Email` field as `search_fields` in the `secure_vocabularies.json`