### PR TITLE
[SUPDESQ-34] - fix issue with dropdown rendering issue

### DIFF
--- a/ckanext/vocabulary_services/fanstatic/add-edit-form.js
+++ b/ckanext/vocabulary_services/fanstatic/add-edit-form.js
@@ -10,8 +10,10 @@ jQuery(document).ready(function () {
     $vocabFormEl.find('#schema').change(function (e) {
         var options = linked_schema_field[$(this).val()];
         $linkedSchemaFieldEl.html('');
-        for (var i = 0; i < options.length; i++) {
-            $linkedSchemaFieldEl.append('<option value="' + options[i].value + '" data-name="' + options[i].name + '">' + options[i].text + '</option>')
+        if (options && options.length > 0) {
+            for (var i = 0; i < options.length; i++) {
+                $linkedSchemaFieldEl.append('<option value="' + options[i].value + '" data-name="' + options[i].name + '">' + options[i].text + '</option>')
+            }
         }
 
         $linkedSchemaFieldEl.change();

--- a/ckanext/vocabulary_services/helpers.py
+++ b/ckanext/vocabulary_services/helpers.py
@@ -105,7 +105,7 @@ def get_linked_schema_field_options(existing_vocab_services, force_include_vocab
     def existing_field_names(package_type):
         field_names = [service.linked_schema_field for service in existing_vocab_services if len(service.linked_schema_field.strip()) > 0 and service.schema == package_type]
 
-        if force_include_vocab and len(force_include_vocab.linked_schema_field.strip()) > 0 and force_include_vocab.linked_schema_field in field_names:
+        if force_include_vocab and not isinstance(force_include_vocab, dict) and len(force_include_vocab.linked_schema_field.strip()) > 0 and force_include_vocab.linked_schema_field in field_names:
             field_names.remove(force_include_vocab.linked_schema_field)
 
         return field_names


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/SUPDESQ-34

fixes:
- js issue when one of the schema is empty
- force_include_vocab should be class instead of dict. dict is passed when submitting the form, and we don't need to check that, so adding a condition here.